### PR TITLE
Feature/filter activity

### DIFF
--- a/NCCommunication/NCCommunication+API.swift
+++ b/NCCommunication/NCCommunication+API.swift
@@ -562,14 +562,18 @@ extension NCCommunication {
         var activities: [NCCommunicationActivity] = []
 
         var endpoint = "ocs/v2.php/apps/activity/api/v2/activity/"
-        var parameters: [String: Any] = ["format":"json"]
+        var parameters: [String: Any] = [
+            "format":"json",
+            "since": String(since),
+            "limit": String(limit)
+        ]
         
-        if objectId == nil {
-            endpoint += "all"
-            parameters = ["since": String(since), "limit": String(limit)]
-        } else if let objectId = objectId, let objectType = objectType {
+        if let objectId = objectId, let objectType = objectType {
             endpoint += "filter"
-            parameters = ["since": String(since), "limit": String(limit), "object_id": objectId, "object_type": objectType]
+            parameters["object_id"] = objectId
+            parameters["object_type"] = objectType
+        } else {
+            endpoint += "all"
         }
 
         if previews {


### PR DESCRIPTION
## [NC Activity Docs](https://github.com/nextcloud/activity/blob/master/docs/endpoint-v2.md)
> `/all` is all activity so your stream from https://cloud.nextcloud.com/apps/activity/ and `/filter` is to filter it down to an object
@nickvergessen 

Use `/all` only when no Object-ID and type is specified. Otherwise use `/filter` to request activities for a specific file.
Also, include `format` in parameter array for more consistency.