### PR TITLE
Fix `resizeImage(...)`

### DIFF
--- a/NCCommunication/UIImage+Extensions.swift
+++ b/NCCommunication/UIImage+Extensions.swift
@@ -41,13 +41,9 @@ extension UIImage {
             }
         }
 
-        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
-        self.draw(in: CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height))
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        if let image = newImage {
-            return image
-        }
-        return self
+        UIGraphicsBeginImageContextWithOptions(newSize, true, 1.0)
+        self.draw(in: CGRect(origin: .zero, size: newSize))
+        defer { UIGraphicsEndImageContext() }
+        return UIGraphicsGetImageFromCurrentImageContext()
     }
 }

--- a/NCCommunication/UIImage+Extensions.swift
+++ b/NCCommunication/UIImage+Extensions.swift
@@ -4,8 +4,10 @@
 //
 //  Created by Marino Faggiana on 21/12/20.
 //  Copyright © 2020 Marino Faggiana. All rights reserved.
+//  Copyright © 2021 Henrik Storch. All rights reserved.
 //
 //  Author Marino Faggiana <marino.faggiana@nextcloud.com>
+//  Author Henrik Storch <henrik.storch@nextcloud.com>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -22,60 +24,30 @@
 //
 
 import UIKit
-import Accelerate
 
 extension UIImage {
-    
     internal func resizeImage(size: CGSize, isAspectRation: Bool) -> UIImage? {
-        
         let originRatio = self.size.width / self.size.height
         let newRatio = size.width / size.height
         var newSize = size
-        let cgImage = self.cgImage!
 
         if isAspectRation {
             if originRatio < newRatio {
                 newSize.height = size.height
                 newSize.width = size.height * originRatio
             } else {
-                newSize.width = size.width;
+                newSize.width = size.width
                 newSize.height = size.width / originRatio
             }
         }
-        
-        var format = vImage_CGImageFormat(bitsPerComponent: 8, bitsPerPixel: 32, colorSpace: nil, bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.first.rawValue), version: 0, decode: nil, renderingIntent: CGColorRenderingIntent.defaultIntent)
-        var sourceBuffer = vImage_Buffer()
-        
-        defer {
-            free(sourceBuffer.data)
+
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+        self.draw(in: CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        if let image = newImage {
+            return image
         }
-        
-        var error = vImageBuffer_InitWithCGImage(&sourceBuffer, &format, nil, cgImage, numericCast(kvImageNoFlags))
-        guard error == kvImageNoError else { return nil }
-        
-        // create a destination buffer
-        let destWidth = Int(newSize.width)
-        let destHeight = Int(newSize.height)
-        let bytesPerPixel = self.cgImage!.bitsPerPixel/8
-        let destBytesPerRow = destWidth * bytesPerPixel
-        let destData = UnsafeMutablePointer<UInt8>.allocate(capacity: destHeight * destBytesPerRow)
-        defer {
-            destData.deallocate()
-        }
-        var destBuffer = vImage_Buffer(data: destData, height: vImagePixelCount(destHeight), width: vImagePixelCount(destWidth), rowBytes: destBytesPerRow)
-        
-        // scale the image
-        error = vImageScale_ARGB8888(&sourceBuffer, &destBuffer, nil, numericCast(kvImageHighQualityResampling))
-        guard error == kvImageNoError else { return nil }
-        
-        // create a CGImage from vImage_Buffer
-        var destCGImage = vImageCreateCGImageFromBuffer(&destBuffer, &format, nil, nil, numericCast(kvImageNoFlags), &error)?.takeRetainedValue()
-        guard error == kvImageNoError else { return nil }
-        
-        // create a UIImage
-        let resizedImage = destCGImage.flatMap { UIImage(cgImage: $0, scale: 0.0, orientation: self.imageOrientation) }
-        destCGImage = nil
-        
-        return resizedImage
+        return self
     }
 }


### PR DESCRIPTION
There was a problem with `vImageScale_ARGB8888(...)` which would cause a runtime error: EXC_BAD_ACCESS.
Using UIGraphicsContext is Swiftier, more readable, and safer, since it fixes the error and avoids handling raw pointers / buffers.

Fix in the Nextcloud/iOS repo: Nextcloud/ios@8a0ca1fced6b373d41885c1b2105dd75727ebab8